### PR TITLE
Updating grunt-link to work with Grunt 0.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
+before_script:
+  - npm install -g grunt-cli
 language: node_js
 node_js:
-  - 0.6
   - 0.8

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -6,14 +6,12 @@ module.exports = function (grunt) {
         nodeunit: {
             all: ['test/link_test.js']
         },
-        lint: {
-            files: ['grunt.js', 'tasks/**/*.js', 'test/**/*.js']
-        },
         watch: {
             files: '<config:lint.files>',
             tasks: 'default'
         },
         jshint: {
+            all: ['grunt.js', 'tasks/**/*.js', 'test/**/*.js'],
             options: {
                 curly: true,
                 eqeqeq: true,
@@ -38,9 +36,10 @@ module.exports = function (grunt) {
     // Load local tasks.
     grunt.loadTasks('tasks');
     grunt.loadNpmTasks('grunt-contrib-nodeunit');
+    grunt.loadNpmTasks('grunt-contrib-jshint');
 
     // Default task.
-    grunt.registerTask('test', 'link nodeunit:all');
-    grunt.registerTask('default', 'lint test');
+    grunt.registerTask('test', ['link','nodeunit:all']);
+    grunt.registerTask('default', ['jshint','test']);
 
 };

--- a/package.json
+++ b/package.json
@@ -1,44 +1,48 @@
 {
-    "name": "grunt-link",
-    "description": "Grunt task to handle the linking of local dependencies",
-    "version": "0.0.1",
-    "homepage": "http://doug-martin.github.com/grunt-link",
-    "author": {
-        "name": "Doug Martin",
-        "email": "doug@dougamartin.com",
-        "url": "http://blog.dougamartin.com"
-    },
-    "repository": {
-        "type": "git",
-        "url": "doug-martin/grunt-link.git"
-    },
-    "bugs": {
-        "url": ""
-    },
-    "licenses": [
-        {
-            "type": "MIT",
-            "url": "http://doug-martin.github.com/grunt-link/blob/master/LICENSE-MIT"
-        }
-    ],
-    "main": "grunt.js",
-    "engines": {
-        "node": "*"
-    },
-    "scripts": {
-        "test": "grunt test"
-    },
-    "devDependencies": {
-        "grunt": "~0.3.17",
-        "grunt-contrib-nodeunit": "~0.1.1"
-    },
-    "keywords": [
-        "gruntplugin",
-        "npm",
-        "link"
-    ],
-    "dependencies": {
-        "comb": "~0.2.1",
-        "rimraf": "~2.1.1"
+  "name": "grunt-link",
+  "description": "Grunt task to handle the linking of local dependencies",
+  "version": "0.0.1",
+  "homepage": "http://doug-martin.github.com/grunt-link",
+  "author": {
+    "name": "Doug Martin",
+    "email": "doug@dougamartin.com",
+    "url": "http://blog.dougamartin.com"
+  },
+  "repository": {
+    "type": "git",
+    "url": "doug-martin/grunt-link.git"
+  },
+  "bugs": {
+    "url": ""
+  },
+  "licenses": [
+    {
+      "type": "MIT",
+      "url": "http://doug-martin.github.com/grunt-link/blob/master/LICENSE-MIT"
     }
+  ],
+  "main": "Gruntfile.js",
+  "engines": {
+    "node": "*"
+  },
+  "scripts": {
+    "test": "grunt test"
+  },
+  "peerDependencies": {
+    "grunt": "~0.4.0"
+  },
+  "devDependencies": {
+    "grunt": "~0.4.0",
+    "grunt-contrib-nodeunit": "~0.1.2",
+    "grunt-contrib-jshint": "~0.2.0"
+  },
+  "keywords": [
+    "gruntplugin",
+    "npm",
+    "link"
+  ],
+  "dependencies": {
+    "comb": "~0.2.1",
+    "rimraf": "~2.1.1"
+  }
 }

--- a/tasks/link.js
+++ b/tasks/link.js
@@ -20,7 +20,7 @@ module.exports = function (grunt) {
     // ==========================================================================
 
     grunt.registerTask('link', 'Your task description goes here.', function () {
-        var options = grunt.utils._.extend({ignoreCyclic: false, dir: process.cwd(), install: true}, grunt.config("link")),
+        var options = grunt.util._.extend({ignoreCyclic: false, dir: process.cwd(), install: true}, grunt.config("link")),
             done,
             cwd;
         if (options.dir) {

--- a/test/link_test.js
+++ b/test/link_test.js
@@ -16,7 +16,7 @@ exports.link = {
         test.ok(isLink("test/test-project/moduleB/node_modules/module-a"));
         test.ok(isLink("test/test-project/moduleC/node_modules/module-a"));
         test.ok(isLink("test/test-project/moduleC/node_modules/module-b"));
-        test.equal(grunt.file.expandDirs("test/test-project/moduleA/node_modules").length, 0);
+        test.equal(grunt.file.expand("test/test-project/moduleA/node_modules").length, 0);
         test.done();
     }
 };


### PR DESCRIPTION
- updated to new batched alias syntax (array instead of a string)
- Renemed grunt.js to Gruntfile.js
- Added Grunt 0.4 as a dev dependency
- grunt.utils has been renamed to grunt.util
- grunt.file.expandDirs has been dropped in favor of grunt.utils.expand
