### PR TITLE
Fix handling of duplicate linkDependencies

### DIFF
--- a/tasks/lib/link_helper.js
+++ b/tasks/lib/link_helper.js
@@ -1,6 +1,7 @@
 "use strict";
 
 var path = require("path"),
+    comb = require("comb"),
     fs = require("fs");
 
 module.exports = function (baseDir) {
@@ -71,7 +72,16 @@ module.exports = function (baseDir) {
         var packages = gatherPackages(),
             ret = {};
         Object.keys(packages).forEach(function (location) {
-            ret[location] = packages[location].linkDependencies || [];
+
+            var linkDependencies = packages[location].linkDependencies || [];
+            var uniqueDeps = comb(linkDependencies).unique();
+
+            if (uniqueDeps.length < linkDependencies.length) {
+                console.warn("Duplicate link dependencies in package ", location);
+            }
+
+            ret[location] = uniqueDeps;
+
         });
         return ret;
     }

--- a/test/link_test.js
+++ b/test/link_test.js
@@ -8,15 +8,22 @@ function isLink(loc) {
     return fs.lstatSync(path.resolve(process.cwd(), loc)).isSymbolicLink();
 }
 
+function exists(loc) {
+    var res =  fs.existsSync(path.resolve(process.cwd(), loc));
+    return res;
+}
+
 exports.link = {
     'link': function (test) {
-        test.expect(5);
+        test.expect(6);
 
         // tests here
         test.ok(isLink("test/test-project/moduleB/node_modules/module-a"));
         test.ok(isLink("test/test-project/moduleC/node_modules/module-a"));
         test.ok(isLink("test/test-project/moduleC/node_modules/module-b"));
         test.ok(isLink("test/test-project/moduleC/node_modules/module-d"));
+        test.ok(!exists("test/test-project/moduleB/module-b"), "duplicate link to module-b should not exists");
+
         test.equal(grunt.file.expand("test/test-project/moduleA/node_modules").length, 0);
         test.done();
     }

--- a/test/test-project/moduleB/package.json
+++ b/test/test-project/moduleB/package.json
@@ -1,5 +1,5 @@
 {
     "name": "module-b",
     "version" : "0.0.1",
-    "linkDependencies": ["module-a"]
+    "linkDependencies": ["module-a", "module-a"]
 }


### PR DESCRIPTION
When specifying linkDependencies multiple time,
grunt-link would either fail with a warning about
cyclic graph, or create symbolic links in
unexpected region.

Fixed by adding a console warning and ignoring
duplicates.
