### PR TITLE
Update for Node 6.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "grunt-link",
   "description": "Grunt task to handle the linking of local dependencies",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "homepage": "https://github.com/doug-martin/grunt-link.git",
   "author": {
     "name": "Doug Martin",
@@ -17,6 +17,10 @@
       "name": "Russell Madsen",
       "email": "russell@madsendev.com",
       "url": "http://madsendev.com"
+    },
+    {
+      "name": "Miko Nieminen",
+      "email": "miko.nieminen@iki.fi"
     }
   ],
   "repository": {
@@ -26,12 +30,7 @@
   "bugs": {
     "url": ""
   },
-  "licenses": [
-    {
-      "type": "MIT",
-      "url": "http://doug-martin.github.com/grunt-link/blob/master/LICENSE-MIT"
-    }
-  ],
+  "license": "(MIT)",
   "main": "Gruntfile.js",
   "engines": {
     "node": "*"
@@ -40,12 +39,12 @@
     "test": "grunt test"
   },
   "peerDependencies": {
-    "grunt": "~0.4.0"
+    "grunt": "~1.0.1"
   },
   "devDependencies": {
-    "grunt": "~0.4.0",
-    "grunt-contrib-nodeunit": "~0.1.2",
-    "grunt-contrib-jshint": "~0.2.0"
+    "grunt": "~1.0.1",
+    "grunt-contrib-jshint": "~1.1.0",
+    "grunt-contrib-nodeunit": "~1.0.0"
   },
   "keywords": [
     "gruntplugin",
@@ -53,8 +52,8 @@
     "link"
   ],
   "dependencies": {
-    "comb": "~0.4.0",
-    "rimraf": "~2.1.1",
-    "npm": "^1.4.21"
+    "comb": "~1.0.1",
+    "rimraf": "~2.5.4",
+    "npm": "~3.10.8"
   }
 }

--- a/test/link_test.js
+++ b/test/link_test.js
@@ -17,7 +17,7 @@ exports.link = {
         test.ok(isLink("test/test-project/moduleC/node_modules/module-a"));
         test.ok(isLink("test/test-project/moduleC/node_modules/module-b"));
         test.ok(isLink("test/test-project/moduleC/node_modules/module-d"));
-        test.equal(grunt.file.expand("test/test-project/moduleA/node_modules").length, 0);
+        test.equal(grunt.file.expand("test/test-project/moduleA/node_modules/*").length, 0);
         test.done();
     }
 };


### PR DESCRIPTION
I updated the package for mode 6.x to get rid of some warnings and complains and to use more recent versions of different components.

This also fixes issues where component depends on other linked component and you want to add this dependency in both: linkedDependencies and dependencies. When using node 6.x this scenario is broken. Updating to npm 3.10.8 seems to fix it.

Broken scenario this fixes:
- module-a
- module-b: depends module-a (add module-a in linkedDepdencies and dependencies)
